### PR TITLE
Add macOS app support via Mac Catalyst (+ bug fixes)

### DIFF
--- a/LoopMusic.xcodeproj/project.pbxproj
+++ b/LoopMusic.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 		39EC8AE1245A6E0F00D5240D /* PlaylistListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistListViewController.swift; sourceTree = "<group>"; };
 		39F1799922DBCD4800D3CDFF /* AudioEngine.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = AudioEngine.c; sourceTree = "<group>"; };
 		92252D1424C025F80033A854 /* fa-solid-900.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "fa-solid-900.ttf"; sourceTree = "<group>"; };
+		92268BEF26F68D72004C9558 /* LoopMusic.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LoopMusic.entitlements; sourceTree = "<group>"; };
 		9252279B24C419DC00E25C15 /* FontUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontUtils.swift; sourceTree = "<group>"; };
 		9252AC9C24C9FFDE00310CF1 /* DataCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCleaner.swift; sourceTree = "<group>"; };
 		9252AC9E24CA040E00310CF1 /* DataImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataImporter.swift; sourceTree = "<group>"; };
@@ -308,6 +309,7 @@
 		390BDA9D22AA0CE600E01411 /* LoopMusic */ = {
 			isa = PBXGroup;
 			children = (
+				92268BEF26F68D72004C9558 /* LoopMusic.entitlements */,
 				390BDAA822AA0CE700E01411 /* Assets.xcassets */,
 				92252D1324C025F80033A854 /* Fonts */,
 				390BDAAD22AA0CE700E01411 /* Info.plist */,
@@ -835,15 +837,20 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = LoopMusic/LoopMusic.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = CTR8N8VQUB;
 				INFOPLIST_FILE = LoopMusic/Info.plist;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = LoopMusic.LoopMusicSwift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "LoopMusic/Source/LoopMusic-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -856,15 +863,20 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = LoopMusic/LoopMusic.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = CTR8N8VQUB;
 				INFOPLIST_FILE = LoopMusic/Info.plist;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = LoopMusic.LoopMusicSwift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "LoopMusic/Source/LoopMusic-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/LoopMusic/LoopMusic.entitlements
+++ b/LoopMusic/LoopMusic.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.assets.music.read-only</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/LoopMusic/Source/Utils/MessageError.swift
+++ b/LoopMusic/Source/Utils/MessageError.swift
@@ -22,10 +22,12 @@ struct MessageError: Error {
     init(_ message: String, _ statusCode: Int32) {
         self.message = String(format: "%@ Status code: %d", message, statusCode)
     }
-    
+}
+
+extension MessageError: LocalizedError {
     /// Gets the message describing the error. Mirrors NSError's localizedDescription().
     /// - returns: Message describing the error.
-    public var localizedDescription: String {
+    public var errorDescription: String? {
         return message
     }
 }

--- a/LoopMusic/Source/ViewControllers/MusicPlayerViewController.swift
+++ b/LoopMusic/Source/ViewControllers/MusicPlayerViewController.swift
@@ -106,7 +106,9 @@ class MusicPlayerViewController: UIViewController, LoopScrubberContainer, UIAdap
     
     /// Updates UI elements when starting, pausing, or stopping the current track.
     func updateOnPlay() {
-        loopScrubber?.updateValue() // Make sure the scrubber value is up to date
+        if MusicPlayer.player.trackLoaded {
+            loopScrubber?.updateValue() // Make sure the scrubber value is up to date
+        }
         if MusicPlayer.player.playing {
             loopScrubber?.playTrack()
         } else if MusicPlayer.player.paused {


### PR DESCRIPTION
Turn on Mac Catalyst to add support for a macOS app. This requires one minor change for compatibility: escaping track URLs in `Tracks.db` (since URLs are real file paths on the macOS app, and can have single quotes). One noteworthy non-default config required to make the music player work without requiring additional code changes (à la `startAccessingSecurityScopedResource`) is granting read-only access to the Music Folder in the App Sandbox settings.

Minor bug fixes include not crashing at startup if no track is loaded (from a bad loop scrubber update), and properly propagating error messages with `MessageError`.

## How to transfer data between iOS/macOS apps

We should probably add some sort of data import/export feature, but until then, it's not too hard to transfer data files manually.

- The macOS data directory for a local debug build seems to be `$HOME/Library/Containers/LoopMusic.LoopMusicSwift/Data/Documents`. `Settings.plist` and `Tracks.db` can be moved freely to/from this directory.
- iOS data can be moved around the normal way through Xcode using the `Window > Devices & Simulators` window. From the settings gear icon, the container can be exported from the "Download Container" option. The data in the `Documents/` directory can be modified freely, and the new container can be imported back to the device via the "Replace Container" option.

Note that the `url` columns won't match between the macOS and iOS apps, but the app's fallback-by-track-name behavior should make the two compatible, provided the Apple Music libraries are properly synced between devices.